### PR TITLE
Adding reactions methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+* Your contribution here.
+
+* Added `reactions.add` - [@jakedahn](https://jake.ai)
+* Added `reactions.list` - [@jakedahn](https://jake.ai)
+* Added `reactions.get` - [@jakedahn](https://jake.ai)
+* Added `reactions.remove` - [@jakedahn](https://jake.ai)
 * Added `users.list#presence` - [@dblock](https://github.com/dblock).
 * Documented `user_disabled` error in `im.open` - [@dblock](https://github.com/dblock).
 * Added `im.history#inclusive`, fixed `#count` which is an integer - [@dblock](https://github.com/dblock).
@@ -13,3 +19,4 @@ Changelog
 * Added `channels.history#inclusive`, fixed `#count` which is an integer - [@dblock](https://github.com/dblock).
 * Fixed wrong description in `groups.close` - [@shonenada](https://github.com/shonenada).
 * Initial fork, updated December 22, 2014 from https://github.com/slackhq/slack-api-docs - [@dblock](https://github.com/dblock).
+

--- a/methods/reactions.add.json
+++ b/methods/reactions.add.json
@@ -1,0 +1,44 @@
+{
+  "desc": "This method adds a reaction (emoji) to an item (file, file comment, channel message, group message, or direct message). One of file, file_comment, or the combination of channel and timestamp must be specified.",
+  "args": {
+    "name": {
+      "example": "thumbsup",
+      "required": true,
+      "desc": "Reaction (emoji) name."
+    },
+    "file": {
+      "example": "F1234567890",
+      "required": false,
+      "desc": "File to add reaction to."
+    },
+    "file_comment": {
+      "example": "Fc1234567890",
+      "required": false,
+      "desc": "File comment to add reaction to."
+    },
+    "channel": {
+      "example": "C1234567890",
+      "required": false,
+      "desc": "Channel where the message to add reaction to was posted."
+    },
+    "timestamp": {
+      "example": "1234567890.123456",
+      "required": false,
+      "desc": "Timestamp of the message to add reaction to."
+    }
+  },
+  "errors": {
+    "bad_timestamp": "Value passed for timestamp was invalid.",
+    "file_not_found": "File specified by file does not exist.",
+    "file_comment_not_found": "File comment specified by file_comment does not exist.",
+    "message_not_found": "Message specified by channel and timestamp does not exist.",
+    "no_item_specified": "file, file_comment, or combination of channel and timestamp was not specified.",
+    "invalid_name": "Value passed for name was invalid.",
+    "already_reacted": "The specified item already has the user/reaction combination.",
+    "too_many_emoji": "The limit for distinct reactions (i.e emoji) on the item has been reached.",
+    "too_many_reactions": "The limit for reactions a person may add to the item has been reached.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}

--- a/methods/reactions.get.json
+++ b/methods/reactions.get.json
@@ -1,0 +1,45 @@
+{
+  "desc": "This method returns a list of all reactions for a single item (file, file comment, channel message, group message, or direct message).",
+  "args": {
+    "name": {
+      "example": "thumbsup",
+      "required": "required",
+      "desc": "Reaction (emoji) name."
+    },
+    "file": {
+      "example": "F1234567890",
+      "required": false,
+      "desc": "File to add reaction to."
+    },
+    "file_comment": {
+      "example": "Fc1234567890",
+      "required": false,
+      "desc": "File comment to add reaction to."
+    },
+    "channel": {
+      "example": "C1234567890",
+      "required": false,
+      "desc": "Channel where the message to add reaction to was posted."
+    },
+    "timestamp": {
+      "example": "1234567890.123456",
+      "required": false,
+      "desc": "Timestamp of the message to add reaction to."
+    },
+    "full": {
+      "example": true,
+      "required": false,
+      "desc": "If true always return the complete reaction list."
+    }
+  },
+  "errors": {
+    "bad_timestamp": "Value passed for timestamp was invalid.",
+    "file_not_found": "File specified by file does not exist.",
+    "file_comment_not_found": "File comment specified by file_comment does not exist.",
+    "message_not_found": "Message specified by channel and timestamp does not exist.",
+    "no_item_specified": "file, file_comment, or combination of channel and timestamp was not specified.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}

--- a/methods/reactions.list.json
+++ b/methods/reactions.list.json
@@ -1,0 +1,33 @@
+{
+  "desc": "This method returns a list of all items (file, file comment, channel message, group message, or direct message) reacted to by a user.",
+  "args": {
+    "user": {
+      "example": "U1234567890",
+      "required": false,
+      "desc": "Show reactions made by this user. Defaults to the authed user."
+    },
+    "full": {
+      "example": true,
+      "required": false,
+      "desc": "If true always return the complete reaction list."
+    },
+    "count": {
+      "example": 100,
+      "required": false,
+      "default": 100,
+      "desc": "Number of items to return per page."
+    },
+    "page": {
+      "example": 2,
+      "required": false,
+      "default": 1,
+      "desc": "Page number of results to return."
+    }
+  },
+  "errors": {
+    "user_not_found": "Value passed for user was invalid",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}

--- a/methods/reactions.remove.json
+++ b/methods/reactions.remove.json
@@ -1,0 +1,42 @@
+{
+  "desc": "This method removes a reaction (emoji) from an item (file, file comment, channel message, group message, or direct message). One of file, file_comment, or the combination of channel and timestamp must be specified.",
+  "args": {
+    "name": {
+      "example": "thumbsup",
+      "required": true,
+      "desc": "Reaction (emoji) name."
+    },
+    "file": {
+      "example": "F1234567890",
+      "required": false,
+      "desc": "File to add reaction to."
+    },
+    "file_comment": {
+      "example": "Fc1234567890",
+      "required": false,
+      "desc": "File comment to add reaction to."
+    },
+    "channel": {
+      "example": "C1234567890",
+      "required": false,
+      "desc": "Channel where the message to add reaction to was posted."
+    },
+    "timestamp": {
+      "example": "1234567890.123456",
+      "required": false,
+      "desc": "Timestamp of the message to add reaction to."
+    }
+  },
+  "errors": {
+    "bad_timestamp": "Value passed for timestamp was invalid.",
+    "file_not_found": "File specified by file does not exist.",
+    "file_comment_not_found": "File comment specified by file_comment does not exist.",
+    "message_not_found": "Message specified by channel and timestamp does not exist.",
+    "no_item_specified": "file, file_comment, or combination of channel and timestamp was not specified.",
+    "invalid_name": "Value passed for name was invalid.",
+    "no_reaction": "The specified item does not have the user/reaction combination.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}


### PR DESCRIPTION
As requested in https://github.com/dblock/slack-ruby-client/pull/8 I've manually added reaction endpoints based on the public api docs website.